### PR TITLE
changed jdk version and added working exploit poc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /home/gradle/src
 RUN gradle bootJar --no-daemon
 
 
-FROM openjdk:8u191-jdk-alpine
+FROM openjdk:8u181-jdk-alpine
 EXPOSE 8080
 RUN mkdir /app
 COPY --from=builder /home/gradle/src/build/libs/*.jar /app/spring-boot-application.jar


### PR DESCRIPTION
As per the [blog post](https://www.lunasec.io/docs/blog/log4j-zero-day/), JDK version greater than `8u191` is not affected by the LDAP vector so changed the version to `8u181` and verified the RCE works. 
Added working POC in the readme that uses [JNDIExploit](https://github.com/feihong-cs/JNDIExploit) tool instead of marshalsec.