### PR TITLE
Use 7.3.1-jdk17 docker image to support non-amd64 arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.3.1-jdk17-alpine AS builder
+FROM gradle:7.3.1-jdk17 AS builder
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle bootJar --no-daemon


### PR DESCRIPTION
https://hub.docker.com/_/gradle?tab=tags&page=1&name=7.3.1-jdk17