### PR TITLE
Add rm flag in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ It uses Log4j 2.14.1 (through `spring-boot-starter-log4j2` 2.6.1) and the JDK 1.
 Run it:
 
 ```bash
-docker run --name vulnerable-app -p 8080:8080 ghcr.io/christophetd/log4shell-vulnerable-app
+docker run --name vulnerable-app --rm -p 8080:8080 ghcr.io/christophetd/log4shell-vulnerable-app
 ```
 
 Build it yourself (you don't need any Java-related tooling):
 
 ```bash
 docker build . -t vulnerable-app
-docker run -p 8080:8080 --name vulnerable-app vulnerable-app
+docker run -p 8080:8080 --name vulnerable-app --rm vulnerable-app
 ```
 
 ## Exploitation steps


### PR DESCRIPTION
Simply added rm flag in documentation that clean up the container when the container exits. 
https://docs.docker.com/engine/reference/run/#clean-up---rm