### PR TITLE
Directory '/home/gradle/src' does not contain a Gradle build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM gradle:7.3.1-jdk17 AS builder
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
+RUN gradle init
 RUN gradle bootJar --no-daemon
 
 


### PR DESCRIPTION
Tried building, but ran into this issue but adding gradle init seems to fix that issue